### PR TITLE
remove duplicate contexts - support array

### DIFF
--- a/src/util/ClassUtil.php
+++ b/src/util/ClassUtil.php
@@ -52,7 +52,18 @@ class ClassUtil {
             if ($value instanceof \JsonSerializable) {
                 $value = $value->jsonSerialize();
                 if (is_array($value) && array_key_exists($contextProperty, $value)) {
-                    if ($value[$contextProperty] == $parent->getContext()) {
+                    if (is_array($value[$contextProperty]) && count($value[$contextProperty]) > 1) {
+                        // inner object has array of contexts - not trying to thin
+                        continue;
+                    } elseif (is_array($value[$contextProperty]) && count($value[$contextProperty]) === 1) {
+                        $comparableContext = array_pop($value[$contextProperty]);
+                    } else {
+                        $comparableContext = $value[$contextProperty];
+                    }
+                    $parentContext = $parent->getContext()->getValue();
+                    if (is_string($parentContext) && $comparableContext == $parent->getContext()) {
+                        $value[$contextProperty] = null;
+                    } elseif (is_array($parentContext) && in_array($comparableContext, $parentContext)) {
                         $value[$contextProperty] = null;
                     }
                 }

--- a/src/util/ClassUtil.php
+++ b/src/util/ClassUtil.php
@@ -55,7 +55,7 @@ class ClassUtil {
                     if (is_array($value[$contextProperty]) && count($value[$contextProperty]) > 1) {
                         // inner object has array of contexts - not trying to thin
                         continue;
-                    } elseif (is_array($value[$contextProperty]) && count($value[$contextProperty]) === 1) {
+                    } elseif (is_array($value[$contextProperty]) && count($value[$contextProperty]) == 1) {
                         $comparableContext = array_pop($value[$contextProperty]);
                     } else {
                         $comparableContext = $value[$contextProperty];

--- a/tests/CaliperTestCase.php
+++ b/tests/CaliperTestCase.php
@@ -8,7 +8,7 @@ require_once 'CaliperTestUtilities.php';
 class CaliperTestCase extends PHPUnit_Framework_TestCase {
     const
         DEFAULT_TIMEZONE = 'UTC',
-        FIXTURE_DIRECTORY_PATH = '/../caliper-common-fixtures/src/test/resources/fixtures/',
+        FIXTURE_DIRECTORY_PATH = '/../caliper-common-fixtures/src/',
         FIXTURE_FILE_EXTENSION = '.json';
 
     /** @var string */

--- a/tests/EventMediaPausedVideoMultiContextTest.php
+++ b/tests/EventMediaPausedVideoMultiContextTest.php
@@ -17,7 +17,6 @@ use IMSGlobal\Caliper\events\MediaEvent;
 
 class CustomContext extends Context {
     const CONTEXT = array('https://some.domain.com/caliper/ctx/v1p1', 'http://purl.imsglobal.org/ctx/caliper/v1p1');
-//  const CONTEXT = 'http://purl.imsglobal.org/ctx/caliper/v1p1';
 }
 
 /**

--- a/tests/EventMediaPausedVideoMultiContextTest.php
+++ b/tests/EventMediaPausedVideoMultiContextTest.php
@@ -1,0 +1,90 @@
+<?php
+require_once 'CaliperTestCase.php';
+
+use IMSGlobal\Caliper\actions\Action;
+use IMSGlobal\Caliper\context\Context;
+use IMSGlobal\Caliper\entities\agent\Organization;
+use IMSGlobal\Caliper\entities\agent\Person;
+use IMSGlobal\Caliper\entities\agent\SoftwareApplication;
+use IMSGlobal\Caliper\entities\lis\CourseSection;
+use IMSGlobal\Caliper\entities\lis\Membership;
+use IMSGlobal\Caliper\entities\lis\Role;
+use IMSGlobal\Caliper\entities\lis\Status;
+use IMSGlobal\Caliper\entities\media\MediaLocation;
+use IMSGlobal\Caliper\entities\media\VideoObject;
+use IMSGlobal\Caliper\entities\session\Session;
+use IMSGlobal\Caliper\events\MediaEvent;
+
+class CustomContext extends Context {
+    const CONTEXT = array('https://some.domain.com/caliper/ctx/v1p1', 'http://purl.imsglobal.org/ctx/caliper/v1p1');
+//  const CONTEXT = 'http://purl.imsglobal.org/ctx/caliper/v1p1';
+}
+
+/**
+ * @requires PHP 5.6.28
+ */
+class EventMediaPausedVideoMultiContext extends CaliperTestCase {
+    function setUp() {
+        parent::setUp();
+
+
+        $this->setTestObject(
+            (new MediaEvent('urn:uuid:956b4a02-8de0-4991-b8c5-b6eebb6b4cab'))
+                ->setContext(new CustomContext(CustomContext::CONTEXT))
+                ->setActor(
+                    (new Person('https://example.edu/users/554433'))
+                )
+                ->setAction(
+                    new Action(Action::PAUSED))
+                ->setObject(
+                    (new VideoObject('https://example.edu/UQVK-dsU7-Y'))
+                        ->setName(
+                            'Information and Welcome'
+                        )
+                        ->setMediaType(
+                            'video/ogg'
+                        )
+                        ->setDuration(
+                            'PT20M20S'
+                        )
+                )
+                ->setTarget(
+                    (new MediaLocation('https://example.edu/UQVK-dsU7-Y?t=321'))
+                        ->setCurrentTime(
+                            'PT05M21S'
+                        )
+                )
+                ->setEventTime(
+                    new \DateTime('2016-11-15T10:15:00.000Z'))
+                ->setEdApp(
+                    (new SoftwareApplication('https://example.edu/player'))->makeReference())
+                ->setGroup(
+                    (new CourseSection('https://example.edu/terms/201601/courses/7/sections/1'))
+                        ->setCourseNumber(
+                            'CPS 435-01'
+                        )
+                        ->setAcademicSession(
+                            'Fall 2016'
+                        )
+                )
+                ->setMembership(
+                    (new Membership('https://example.edu/terms/201601/courses/7/sections/1/rosters/1'))
+                        ->setMember(
+                            (new Person('https://example.edu/users/554433'))->makeReference())
+                        ->setOrganization(
+                            (new Organization('https://example.edu/terms/201601/courses/7/sections/1'))->makeReference())
+                        ->setRoles(
+                            [new Role(Role::LEARNER)])
+                        ->setStatus(
+                            new Status(Status::ACTIVE))
+                        ->setDateCreated(
+                            new \DateTime('2016-08-01T06:00:00.000Z'))
+                )
+                ->setSession(
+                    (new Session('https://example.edu/sessions/1f6442a482de72ea6ad134943812bff564a76259'))
+                        ->setStartedAtTime(
+                            new \DateTime('2016-11-15T10:00:00.000Z'))
+                )
+        );
+    }
+}


### PR DESCRIPTION
If top level object (Event, for example) has array of contexts and not only the single default context - these changes will remove any of the contexts that are already defined in parent from any child object.

based on discussion with @arwhyte - child objects are not expected to have array, thus the change leaves a child object context as-is and does not try to compare arrays.