### PR TITLE
Add check if array key exists in ClassUtil

### DIFF
--- a/src/util/ClassUtil.php
+++ b/src/util/ClassUtil.php
@@ -62,7 +62,7 @@ class ClassUtil {
         }
 
         // Limited coercion support
-        if (is_array($serializationData['@context'])) {
+        if (array_key_exists('@context', $serializationData) && is_array($serializationData['@context'])) {
             foreach ($serializationData['@context'] as $contextItem) {
                 if (is_array($contextItem)) {
                     foreach ($contextItem as $contextKey => $contextCoercion) {


### PR DESCRIPTION
I've been getting this multiple times for a single event:
`Notice: Undefined index: @context in /var/www/html/vendor/imsglobal/caliper/src/util/ClassUtil.php on line 65`