### PR TITLE
verify @context element exists in $serializationData before checking if it is array

### DIFF
--- a/src/util/ClassUtil.php
+++ b/src/util/ClassUtil.php
@@ -62,7 +62,7 @@ class ClassUtil {
         }
 
         // Limited coercion support
-        if (is_array($serializationData['@context'])) {
+        if (isset($serializationData['@context']) && is_array($serializationData['@context'])) {
             foreach ($serializationData['@context'] as $contextItem) {
                 if (is_array($contextItem)) {
                     foreach ($contextItem as $contextKey => $contextCoercion) {


### PR DESCRIPTION
without this, on my PHP 7.1.4 environment, the tests fails on 'undefined index @context' in this line.
after this change, unit tests can be executed and pass as expected.
